### PR TITLE
Add recurse example

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -187,6 +187,14 @@ EXAMPLES = r'''
     path: /etc/another_file
     state: file
     access_time: '{{ "%Y%m%d%H%M.%S" | strftime(stat_var.stat.atime) }}'
+    
+- name: Recursively change ownership of a directory
+  file:
+    path: /etc/foo
+    recurse: yes
+    owner: foo
+    group: foo
+
 '''
 RETURN = r'''
 


### PR DESCRIPTION
Add recurse example to file module

+label: docsite_pr

##### SUMMARY
Add recurse example to file module docs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
file module docs

##### ADDITIONAL INFORMATION
No example for recursive changes to file ownership in the docs. Thought I would save the next person a few clicks on the google machine by adding an example to the documentation.

```
[ec2-user@adm playbooks]$ ansible-playbook test.yml 

PLAY [localhost] ******************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************
ok: [localhost]

TASK [Recursively change ownership of a directory] ********************************************************************************************************************************
ok: [localhost]

PLAY RECAP ************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```
